### PR TITLE
Improved parsing of MBS2 structure

### DIFF
--- a/Source/BlockInfo.h
+++ b/Source/BlockInfo.h
@@ -58,12 +58,16 @@ struct Block_COMP
 	uint32_t unk1;
 };
 
+
+// Main header for the entire binary
 struct Block_MBS2
 {
 	// MBS2
 	uint32_t cookie;
-	uint32_t unk1;
-	uint32_t unk2;
+	// total size of the binary in bytes, minus 8 bytes for cookie and size.
+	uint32_t size;
+	// some kind of version
+	uint32_t version;
 };
 
 struct Block_VEHW

--- a/Source/BlockInfo.h
+++ b/Source/BlockInfo.h
@@ -187,7 +187,7 @@ struct Block_KWGS
 struct Block_RLOC
 {
 	// RLOC
-	uint32_t unk2;
+	uint32_t location; //uniform location in GL, I think
 	uint32_t unk3;
 	uint32_t unk4;
 	uint32_t unk5;

--- a/Source/BlockInfo.h
+++ b/Source/BlockInfo.h
@@ -130,9 +130,8 @@ struct Block_EBIN
 	// EBIN
 	uint32_t unk2;
 	uint32_t unk3;
-	uint32_t unk4;
+	uint32_t numRelocs;
 	uint32_t unk5;
-	uint32_t unk6;
 };
 
 struct Block_FSHA
@@ -192,6 +191,5 @@ struct Block_RLOC
 	uint32_t unk3;
 	uint32_t unk4;
 	uint32_t unk5;
-	uint32_t unk6;
 
 };

--- a/Source/BlockInfo.h
+++ b/Source/BlockInfo.h
@@ -6,6 +6,12 @@ constexpr uint32_t COOKIE(const char a[4])
 	return (a[3] << 24) | (a[2] << 16) | (a[1] << 8) | a[0];
 };
 
+struct Header
+{
+	uint32_t cookie;
+	uint32_t size;
+};
+
 // Block Types seen
 //
 // MPB1
@@ -29,101 +35,36 @@ constexpr uint32_t COOKIE(const char a[4])
 
 struct Block_MPB1
 {
-	// MPB1
-	uint32_t cookie;
-	// Size of the file sub 0x8
-	uint32_t size;
 	uint32_t unk1;
 	uint32_t unk2;
 };
 
-struct Block_VERT
-{
-	// VERT
-	uint32_t cookie;
-	uint32_t unk1;
-};
-
-struct Block_FRAG
-{
-	// FRAG
-	uint32_t cookie;
-	uint32_t unk1;
-};
-
-struct Block_COMP
-{
-	// COMP
-	uint32_t cookie;
-	uint32_t unk1;
-};
-
-
 // Main header for the entire binary
 struct Block_MBS2
 {
-	// MBS2
-	uint32_t cookie;
-	// total size of the binary in bytes, minus 8 bytes for cookie and size.
-	uint32_t size;
 	// some kind of version
 	uint32_t version;
 };
 
 struct Block_VEHW
 {
-	// VEHW
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;
 };
 
-struct Block_CVER
-{
-	// CVER
-	uint32_t cookie;
-	// XXX: Version?
-	uint32_t unk1;
-};
-
-struct Block_CMMN
-{
-	// CMMN
-	uint32_t cookie;
-	uint32_t unk1;
-};
-
 struct Block_VELA
 {
-	// VELA
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 };
 
 struct Block_SSYM
 {
-	// SSYM
-	uint32_t cookie;
-	uint32_t size;
 	uint32_t unk2;
-};
-
-struct Block_SYMB
-{
-	// SYMB
-	uint32_t cookie;
-	uint32_t unk1;
 };
 
 struct Block_STRI
 {
-	// STRI
-	uint32_t cookie;
-	// Size in bytes padded to the nearest word
-	uint32_t size;
 	// There is a string here
 	uint32_t unk1;
 	uint32_t unk2;
@@ -136,16 +77,11 @@ struct Block_TYPE
 	enum Type : uint32_t
 	{
 	};
-	// TYPE
-	uint32_t cookie;
 	Type type;
 };
 
 struct Block_TPGE
 {
-	// TPGE
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;
@@ -158,8 +94,6 @@ struct Block_TPIB
 {
 	// TPIB
 	// Type buffer
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;
@@ -168,7 +102,6 @@ struct Block_TPST
 {
 	// TPST
 	// Type struct
-	uint32_t cookie;
 	// XXX: Haven't seen it to fill it out
 };
 
@@ -176,24 +109,18 @@ struct Block_TPSE
 {
 	// TPSE
 	// Type struct/buffer element
-	uint32_t cookie;
-	uint32_t unk1;
 };
 
 struct Block_TPAR
 {
 	// TPAR
 	// Type array
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 };
 
 struct Block_UBUF
 {
 	// UBUF
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 };
@@ -201,8 +128,6 @@ struct Block_UBUF
 struct Block_EBIN
 {
 	// EBIN
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;
@@ -213,8 +138,6 @@ struct Block_EBIN
 struct Block_FSHA
 {
 	// FSHA
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;
@@ -226,24 +149,18 @@ struct Block_FSHA
 struct Block_BFRE
 {
 	// BFRE
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 };
 
 struct Block_SPDv
 {
 	// SPDv
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 };
 
 struct Block_SPDf
 {
 	// SPDf
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 };
@@ -251,52 +168,18 @@ struct Block_SPDf
 struct Block_SPDc
 {
 	// SPDc
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
-};
-
-struct Block_OBJC
-{
-	// OBJC
-	uint32_t cookie;
-	uint32_t size;
-};
-
-struct Block_CFRA
-{
-	// CFRA
-	uint32_t cookie;
-	uint32_t unk1;
 };
 
 struct Block_BATT
 {
 	// BATT
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
-};
-
-struct Block_CCOM
-{
-	// CCOM
-	uint32_t cookie;
-	uint32_t unk1;
-};
-
-struct Block_KERN
-{
-	// KERN
-	uint32_t cookie;
-	uint32_t unk1;
 };
 
 struct Block_KWGS
 {
 	// KWGS
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t local_x;
 	uint32_t local_y;
 	uint32_t local_z;
@@ -305,8 +188,6 @@ struct Block_KWGS
 struct Block_RLOC
 {
 	// RLOC
-	uint32_t cookie;
-	uint32_t unk1;
 	uint32_t unk2;
 	uint32_t unk3;
 	uint32_t unk4;

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -38,7 +38,7 @@ void PrintFile(std::vector<uint8_t> *fileData, size_t offset = 0, size_t realpos
 {
 	printf("file size is 0x%08llx\n", fileData->size());
 	uint32_t *data = reinterpret_cast<uint32_t*>(fileData->data() + offset);
-	size_t size = std::min(fileData->size() / 4, 50ul);
+	size_t size = fileData->size() / 4;
 	for (size_t i = 0; i < size; i++)
 	{
 		uint32_t word = data[i];
@@ -53,6 +53,8 @@ void PrintFile(std::vector<uint8_t> *fileData, size_t offset = 0, size_t realpos
 			getL(0), getL(8), getL(16), getL(24));
 	}
 }
+
+void iprintf(unsigned indent, const char *format, ...) __attribute__((format(printf, 2, 3)));
 
 void iprintf(unsigned indent, const char *format, ...)
 {
@@ -72,175 +74,98 @@ void DumpInstructions(unsigned indent, uint8_t* instBlob, uint32_t size)
 	uint8_t* instEnd = instBlob + size;
 	while (instBlob != instEnd)
 	{
-		iprintf(indent, "0x%08x\n", *(uint32_t*)instBlob);
+		printf("0x%08x\n", *(uint32_t*)instBlob);
 		instBlob += 4;
 	}
 }
 
 bool PrintBlocks(unsigned indent, uint8_t *data, size_t size);
+bool PrintBlock(unsigned indent, uint8_t **data);
 
 // Attempt to parse a single block with maxSize words
-bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
+bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint32_t size)
 {
-	uint32_t cookie = *reinterpret_cast<uint32_t*>(blockBlob);
 	switch (cookie)
 	{
 	case COOKIE("MPB1"):
 	{
 		Block_MPB1* block = reinterpret_cast<Block_MPB1*>(blockBlob);
-		iprintf(indent, "Block_MPB1\n");
-		indent++;
-		iprintf(indent, "Size: 0x%08x\n", block->size);
-		assert(block->unk1 == 2);
 		assert(block->unk2 == 0);
-		*blockSize = sizeof(Block_MPB1);
 	}
 	break;
 	case COOKIE("VERT"):
-	{
-		Block_VERT* block = reinterpret_cast<Block_VERT*>(blockBlob);
-		iprintf(indent, "Block_VERT\n");
-		iprintf(indent, "unk1 = 0x%08x\n", block->unk1);
-
-		assert(block->unk1 == 0x45c);
-		*blockSize = sizeof(Block_VERT);
-	}
-	break;
+		break;
 	case COOKIE("FRAG"):
-	{
-		Block_FRAG* block = reinterpret_cast<Block_FRAG*>(blockBlob);
-		iprintf(indent, "Block_FRAG\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		assert(block->unk1 == 0x37c);
-		*blockSize = sizeof(Block_FRAG);
-	}
-	break;
+		break;
 	case COOKIE("COMP"):
-	{
-		Block_COMP* block = reinterpret_cast<Block_COMP*>(blockBlob);
-		iprintf(indent, "Block_COMP\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		// XXX: Changes, probably a size
-		//assert(block->unk1 == 0x1a8);
-		*blockSize = sizeof(Block_COMP);
-	}
-	break;
+		break;
 	case COOKIE("MBS2"):
 	{
 		Block_MBS2* block = reinterpret_cast<Block_MBS2*>(blockBlob);
-		iprintf(indent, "Block_MBS2\n");
-		indent++;
-		iprintf(indent, "size = 0x%08x\n", block->size);
-		iprintf(indent, "version = 0x%08x\n", block->version);
-		PrintBlocks(indent, blockBlob + sizeof(Block_MBS2),
-			    block->size - 4); // 4 bytes for version field (?)
-
-		*blockSize = block->size + 8; // 8 bytes for cookie + size
+		iprintf(indent, "\tversion = 0x%08x\n", block->version);
+		PrintBlocks(indent + 1, blockBlob + sizeof(Block_MBS2),
+			    size - sizeof(Block_MBS2));
 	}
 	break;
 	case COOKIE("VEHW"):
 	{
 		Block_VEHW* block = reinterpret_cast<Block_VEHW*>(blockBlob);
-		iprintf(indent, "Block_VEHW\n");
-		assert(block->unk1 == 0xc);
 		assert(block->unk2 == 0xb);
 		assert(block->unk3 == 0x0);
 		assert(block->unk4 == 0x0);
-		*blockSize = sizeof(Block_VEHW);
 	}
 	break;
 	case COOKIE("CVER"):
-	{
-		Block_CVER* block = reinterpret_cast<Block_CVER*>(blockBlob);
-		iprintf(indent, "Block_CVER\n");
-		assert(block->unk1 == 0x434);
-		*blockSize = sizeof(Block_CVER);
-	}
-	break;
+		PrintBlocks(indent + 1, blockBlob, size);
+		break;
 	case COOKIE("CMMN"):
 	{
-		Block_CMMN* block = reinterpret_cast<Block_CMMN*>(blockBlob);
-		iprintf(indent, "Block_CMMN\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
+		assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("VELA"));
+		PrintBlock(indent + 1, &blockBlob);
 
-		// XXX: Sometimes different
-		//assert(block->unk1 == 0x42c);
-		*blockSize = sizeof(Block_CMMN);
+		// symbol tables?
+		for (int i = 0; i < 6; i++) {
+			assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("SSYM"));
+			PrintBlock(indent + 1, &blockBlob);
+		}
+		assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("UBUF"));
+		PrintBlock(indent + 1, &blockBlob);
+
+		uint32_t numBinaries = *reinterpret_cast<uint32_t*>(blockBlob);
+		iprintf(indent, "\tbinaries = %u\n", numBinaries);
+		blockBlob += sizeof(uint32_t);
+
+		for (unsigned i = 0; i < numBinaries; i++)
+		{
+			assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("EBIN"));
+			PrintBlock(indent + 1, &blockBlob);
+		}
 	}
 	break;
 	case COOKIE("VELA"):
 	{
 		Block_VELA* block = reinterpret_cast<Block_VELA*>(blockBlob);
-		iprintf(indent, "Block_VELA\n");
-		assert(block->unk1 == 0x4);
-		assert(block->unk2 == 0x8);
-		*blockSize = sizeof(Block_VELA);
+		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
+		//assert(block->unk2 == 0x8);
 	}
 	break;
 	case COOKIE("SSYM"):
 	{
 		Block_SSYM* block = reinterpret_cast<Block_SSYM*>(blockBlob);
-		iprintf(indent, "Block_SSYM\n");
-		iprintf(indent, "\tsize = 0x%08x\n", block->size);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
 		// XXX: Sometimes different
 		//assert(block->unk2 == 0x2);
 		// XXX: Skipping the entire SSYM because parsing of sub blocks(STRI) aren't complete
-		*blockSize = sizeof(Block_SSYM) + block->size - 4;
 	}
 	break;
 	case COOKIE("SYMB"):
-	{
-		Block_SYMB* block = reinterpret_cast<Block_SYMB*>(blockBlob);
-		iprintf(indent, "Block_SYMB\n");
-		iprintf(indent, "\tunk1: 0x%08x\n", block->unk1);
-		// XXX: Sometimes different
-		//assert(block->unk1 == 0x4c);
-		*blockSize = sizeof(Block_SYMB);
-	}
-	break;
+		break;
 	case COOKIE("STRI"):
 	{
-		Block_STRI block;
-		block.cookie = *reinterpret_cast<uint32_t*>(blockBlob);
-		block.size = *reinterpret_cast<uint32_t*>(blockBlob + 4);
-		block.unk1 = *reinterpret_cast<uint32_t*>(blockBlob + block.size + 8);
-		block.unk2 = *reinterpret_cast<uint32_t*>(blockBlob + block.size + 12);
-		block.unk3 = *reinterpret_cast<uint32_t*>(blockBlob + block.size + 16);
-		block.unk4 = *reinterpret_cast<uint32_t*>(blockBlob + block.size + 20);
-
 		// block.size includes the word aligned zero padding for the string
-		char* name = static_cast<char*>(malloc(block.size));
-		memcpy(name, blockBlob + 8, block.size);
-
-		iprintf(indent, "Block_STRI\n");
-		iprintf(indent, "\tSize: 0x%08x\n", block.size);
-		iprintf(indent, "\tName: %s\n", name);
-		iprintf(indent, "\tunk1 = 0x%08x\n", block.unk1);
-		iprintf(indent, "\tunk2 = 0x%08x\n", block.unk2);
-		iprintf(indent, "\tunk3 = 0x%08x\n", block.unk3);
-		iprintf(indent, "\tunk4 = 0x%08x\n", block.unk4);
-
-		// XXX: Sometimes different
-		//assert(block.unk1 == 0x0);
-		//assert(block.unk2 == 0x22);
-		//assert(block.unk3 == ~0U);
-		//assert(block.unk4 == ~0U);
-		free(name);
-
-		// XXX: Why do some STRI blocks miss unk4?
-		if (block.unk1 == 0x10)
-			*blockSize = sizeof(Block_STRI) + block.size - 12;
-		else if ((block.unk2 & 0xffff0000) == 0xffff0000)
-			*blockSize = sizeof(Block_STRI) + block.size - 4;
-		else if (block.unk2 == 0)
-			*blockSize = sizeof(Block_STRI) + block.size - 4;
-		else
-			*blockSize = sizeof(Block_STRI) + block.size;
-		iprintf(indent, "\tFull block size: 0x%08llx\n", *blockSize);
+		char* name = reinterpret_cast<char*>(blockBlob);
+		iprintf(indent + 1, "%s", name);
 	}
 	break;
 	case COOKIE("TYPE"):
@@ -254,23 +179,18 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
 			}
 		};
 		Block_TYPE* block = reinterpret_cast<Block_TYPE*>(blockBlob);
-		iprintf(indent, "Block_TYPE\n");
 		iprintf(indent, "\ttype: 0x%08x - %s\n", block->type, getType(block->type));
-		*blockSize = sizeof(Block_TYPE);
 	}
 	break;
 	case COOKIE("TPGE"):
 	{
 		Block_TPGE* block = reinterpret_cast<Block_TPGE*>(blockBlob);
-		iprintf(indent, "Block_TPGE\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
 		iprintf(indent, "\tunk5 = 0x%08x\n", block->unk5);
 		//iprintf(indent, "\tunk6 = 0x%08x\n", block->unk6);
 
-		assert(block->unk1 == 0xc);
 		// XXX: Sometimes different
 		//assert(block->unk2 == 0x01020102);
 		//assert(block->unk3 == 0x1);
@@ -278,74 +198,47 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
 		//assert(block->unk4 == 0x8);
 		//assert(block->unk5 == 0x0 || block->unk5 == 0x45535054);
 		//assert(block->unk6 == 0x0 || block->unk6 == 0x3c);
-		*blockSize = sizeof(Block_TPGE);
 	}
 	break;
 	case COOKIE("TPIB"):
 	{
 		Block_TPIB* block = reinterpret_cast<Block_TPIB*>(blockBlob);
-		iprintf(indent, "Block_TPIB\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
 
 		// XXX: Sometimes different
-		//assert(block->unk1 == 0x98);
 		//assert(block->unk2 == 0x304);
 		//assert(block->unk3 == 0x2);
 		//assert(block->unk4 == 0x2);
-		*blockSize = sizeof(Block_TPIB);
 	}
 	break;
 	case COOKIE("TPSE"):
-	{
-		Block_TPSE* block = reinterpret_cast<Block_TPSE*>(blockBlob);
-		iprintf(indent, "Block_TPSE\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		// XXX: Sometimes different
-		//assert(block->unk1 == 0x40);
-		*blockSize = sizeof(Block_TPSE);
-	}
-	break;
+		break;
 	case COOKIE("TPAR"):
 	{
 		Block_TPAR* block = reinterpret_cast<Block_TPAR*>(blockBlob);
-		iprintf(indent, "Block_TPAR\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
-		assert(block->unk1 == 0x20);
 		// XXX: Probably an array size
 		//assert(block->unk2 == 0x18);
-
-		*blockSize = sizeof(Block_TPAR);
 	}
 	break;
 	case COOKIE("UBUF"):
 	{
 		Block_UBUF* block = reinterpret_cast<Block_UBUF*>(blockBlob);
-		iprintf(indent, "Block_UBUF\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
-		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 
 
 		// XXX: sometimes different
-		//assert(block->unk1 == 0x4);
 		//assert(block->unk2 == 0x0);
-		//assert(block->unk3 == 0x1);
 
 		// XXX: unk2...?
-		*blockSize = sizeof(Block_UBUF) + (block->unk2 ? 4 : 0);
 	}
 	break;
 	case COOKIE("EBIN"):
 	{
 		Block_EBIN* block = reinterpret_cast<Block_EBIN*>(blockBlob);
-		iprintf(indent, "Block_EBIN\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
@@ -354,21 +247,21 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
 
 		// XXX: Sometimes different
 		//assert(block->unk1 == 0xd4);
-		assert(block->unk2 == 0x0);
+		//assert(block->unk2 == 0x0);
 		assert(block->unk3 == ~0U);
 		//assert(block->unk4 == 0x0);
 		assert(block->unk5 == 0x0);
 		//assert(block->unk6 == ~0U);
 
 		// XXX: unk4...?
-		*blockSize = sizeof(Block_EBIN) + (block->unk4 ? -4 : 0);
+		blockBlob += sizeof(Block_EBIN);
+		PrintBlocks(indent + 1, blockBlob, size - sizeof(Block_EBIN));
+
 	}
 	break;
 	case COOKIE("FSHA"):
 	{
 		Block_FSHA* block = reinterpret_cast<Block_FSHA*>(blockBlob);
-		iprintf(indent, "Block_FSHA\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
@@ -376,156 +269,113 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
 		iprintf(indent, "\tunk6 = 0x%08x\n", block->unk6);
 		iprintf(indent, "\tunk7 = 0x%08x\n", block->unk7);
 
-		assert(block->unk1 == 0x18);
 		assert(block->unk2 == 0x0);
 		assert(block->unk3 == 0x0);
-		assert(block->unk4 == 0x20);
+		//assert(block->unk4 == 0x20);
 		//assert(block->unk5 == 0x0);
 		// XXX:Sometimes different
 		// Probably a bitfield
 		//assert(block->unk6 == 0x0);
 		assert(block->unk7 == 0x0);
-		*blockSize = sizeof(Block_FSHA);
 	}
 	break;
 	case COOKIE("BFRE"):
 	{
 		Block_BFRE* block = reinterpret_cast<Block_BFRE*>(blockBlob);
-		iprintf(indent, "Block_BFRE\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
 		// XXX: Sometimes different
 		// Probably a bitfield
-		//assert(block->unk1 == 0x10);
 		assert(block->unk2 == 0x0);
-		*blockSize = sizeof(Block_BFRE);
 	}
 	break;
 	case COOKIE("SPDv"):
 	{
 		Block_SPDv* block = reinterpret_cast<Block_SPDv*>(blockBlob);
-		iprintf(indent, "Block_SPDv\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
-		assert(block->unk1 == 0x4);
 		assert(block->unk2 == 0x0);
-		*blockSize = sizeof(Block_SPDv);
 	}
 	break;
 	case COOKIE("SPDf"):
 	{
 		Block_SPDf* block = reinterpret_cast<Block_SPDf*>(blockBlob);
-		iprintf(indent, "Block_SPDf\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 
-		assert(block->unk1 == 0x8);
 		assert(block->unk2 == 0x0080003e);
 		assert(block->unk3 == 0x0);
-		*blockSize = sizeof(Block_SPDf);
 	}
 	break;
 	case COOKIE("SPDc"):
 	{
 		Block_SPDc* block = reinterpret_cast<Block_SPDc*>(blockBlob);
-		iprintf(indent, "Block_SPDc\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
-		assert(block->unk1 == 0x4);
 		assert(block->unk2 == 0x0);
-		*blockSize = sizeof(Block_SPDc);
 	}
 	break;
 
 	case COOKIE("OBJC"):
 	{
-		Block_OBJC* block = reinterpret_cast<Block_OBJC*>(blockBlob);
-		iprintf(indent, "Block_OBJC\n");
-		iprintf(indent, "\tsize = 0x%08x\n", block->size);
-		// XXX: Bunch of instructions here?
-
-		DumpInstructions(indent + 1, blockBlob + 4, block->size);
-		*blockSize = sizeof(Block_OBJC) + block->size;
+		DumpInstructions(indent + 1, blockBlob, size);
 	}
 	break;
 	case COOKIE("CFRA"):
 	{
-		Block_CFRA* block = reinterpret_cast<Block_CFRA*>(blockBlob);
-		iprintf(indent, "Block_CFRA\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		assert(block->unk1 == 0x354);
-		*blockSize = sizeof(Block_CFRA);
+		PrintBlocks(indent + 1, blockBlob, size);
 	}
 	break;
 	case COOKIE("BATT"):
 	{
 		Block_BATT* block = reinterpret_cast<Block_BATT*>(blockBlob);
-		iprintf(indent, "Block_BATT\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 
-		assert(block->unk1 == 0x38);
 		assert(block->unk2 == 0x2);
-		*blockSize = sizeof(Block_BATT);
 	}
 	break;
 	case COOKIE("CCOM"):
-	{
-		Block_CCOM* block = reinterpret_cast<Block_CCOM*>(blockBlob);
-		iprintf(indent, "Block_CCOM\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		// XXX: Probably a size
-		// assert(block->unk1 == 0x180);
-		*blockSize = sizeof(Block_CCOM);
-	}
-	break;
+		break;
 	case COOKIE("KERN"):
-	{
-		Block_KERN* block = reinterpret_cast<Block_KERN*>(blockBlob);
-		iprintf(indent, "Block_KERN\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		assert(block->unk1 == 0x30);
-		*blockSize = sizeof(Block_KERN);
-	}
-	break;
+		break;
 	case COOKIE("KWGS"):
-	{
-		Block_KWGS* block = reinterpret_cast<Block_KWGS*>(blockBlob);
-		iprintf(indent, "Block_KWGS\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
-
-		assert(block->unk1 == 0xc);
-		*blockSize = sizeof(Block_KWGS);
-	}
-	break;
+		break;
 	case COOKIE("RLOC"):
 	{
 		Block_RLOC* block = reinterpret_cast<Block_RLOC*>(blockBlob);
-		iprintf(indent, "Block_RLOC\n");
-		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
 		iprintf(indent, "\tunk5 = 0x%08x\n", block->unk5);
 		iprintf(indent, "\tunk6 = 0x%08x\n", block->unk6);
 
-		assert(block->unk1 == 0x10);
 		assert(block->unk2 == 0x0);
 		assert(block->unk3 == 0x0);
 		assert(block->unk4 == 0x0);
 		assert(block->unk5 == 0x8);
 		// XXX: Sometimes different
 		//assert(block->unk6 == 0x0);
-		*blockSize = sizeof(Block_RLOC);
 	}
 	break;
+	case COOKIE("FOTV"):
+	{
+		// output variables
+		uint32_t numVariables = *reinterpret_cast<uint32_t*>(blockBlob);
+		blockBlob += sizeof(uint32_t);
+		iprintf(indent, "\tvariables = %u\n", numVariables);
+
+		for (unsigned i = 0; i < numVariables; i++)
+		{
+			assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("OUTV"));
+			PrintBlock(indent + 1, &blockBlob);
+		}
+	}
+	case COOKIE("OUTV"):
+		//TODO
+		break;
+	case COOKIE("AINF"):
+		//TODO
+		break;
 
 	default:
 	{
@@ -544,18 +394,31 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, size_t *blockSize)
 	return true;
 }
 
+bool PrintBlock(unsigned indent, uint8_t **data)
+{
+	Header *hdr = reinterpret_cast<Header*>(*data);
+	auto getL = [hdr](int off)
+	{
+		return (uint8_t)(hdr->cookie >> off);
+	};
+	iprintf(indent, "%c%c%c%c\n", getL(0), getL(8), getL(16), getL(24));
+	iprintf(indent, "\tsize = 0x%08x\n", hdr->size);
+	if (!ParseSingleBlock(indent, *data + sizeof(Header), hdr->cookie, hdr->size))
+	{
+		printf("Couldn't parse block! Leaving!\n");
+		return false;
+	}
+
+	*data += hdr->size + sizeof(Header);
+	return true;
+}
+
 bool PrintBlocks(unsigned indent, uint8_t *data, size_t size)
 {
-	for (size_t i = 0; i < size;)
+	for (uint8_t *tmp = data; tmp < data + size;)
 	{
-		size_t blockSize = 0;
-		if (!ParseSingleBlock(indent, &data[i], &blockSize))
-		{
-			printf("Couldn't parse block! Leaving!\n");
+		if (!PrintBlock(indent, &tmp))
 			return false;
-		}
-
-		i += blockSize;
 	}
 
 	return true;

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -90,15 +90,14 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 	case COOKIE("MPB1"):
 	{
 		Block_MPB1* block = reinterpret_cast<Block_MPB1*>(blockBlob);
+		iprintf(indent, "\tunk1 = 0x%08x\n", block->unk1);
+		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		assert(block->unk2 == 0);
+
+		PrintBlocks(indent + 1, blockBlob + sizeof(Block_MPB1),
+			    size - sizeof(Block_MPB1));
 	}
 	break;
-	case COOKIE("VERT"):
-		break;
-	case COOKIE("FRAG"):
-		break;
-	case COOKIE("COMP"):
-		break;
 	case COOKIE("MBS2"):
 	{
 		Block_MBS2* block = reinterpret_cast<Block_MBS2*>(blockBlob);
@@ -115,6 +114,9 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 		assert(block->unk4 == 0x0);
 	}
 	break;
+	case COOKIE("VERT"):
+	case COOKIE("FRAG"):
+	case COOKIE("COMP"):
 	case COOKIE("CVER"):
 		PrintBlocks(indent + 1, blockBlob, size);
 		break;
@@ -353,7 +355,7 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 	case COOKIE("RLOC"):
 	{
 		Block_RLOC* block = reinterpret_cast<Block_RLOC*>(blockBlob);
-		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
+		iprintf(indent, "\tlocation = %u\n", block->location);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
 		iprintf(indent, "\tunk5 = 0x%08x\n", block->unk5);
@@ -443,7 +445,7 @@ int main(int argc, char** argv)
 	std::vector<uint8_t> file;
 	if (ReadFile(&file, argv[1]))
 	{
-		PrintFile(&file);
+		//PrintFile(&file);
 		PrintBlocks(0, file.data(), file.size());
 	}
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -238,12 +238,12 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 	break;
 	case COOKIE("EBIN"):
 	{
+		uint8_t *end = blockBlob + size;
 		Block_EBIN* block = reinterpret_cast<Block_EBIN*>(blockBlob);
 		iprintf(indent, "\tunk2 = 0x%08x\n", block->unk2);
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
-		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
+		iprintf(indent, "\trelocs = %u\n", block->numRelocs);
 		iprintf(indent, "\tunk5 = 0x%08x\n", block->unk5);
-		iprintf(indent, "\tunk6 = 0x%08x\n", block->unk6);
 
 		// XXX: Sometimes different
 		//assert(block->unk1 == 0xd4);
@@ -253,9 +253,19 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 		assert(block->unk5 == 0x0);
 		//assert(block->unk6 == ~0U);
 
-		// XXX: unk4...?
 		blockBlob += sizeof(Block_EBIN);
-		PrintBlocks(indent + 1, blockBlob, size - sizeof(Block_EBIN));
+
+		for (unsigned i = 0; i < block->numRelocs; i++)
+		{
+			assert(*reinterpret_cast<uint32_t*>(blockBlob) == COOKIE("RLOC"));
+			PrintBlock(indent + 1, &blockBlob);
+		}
+
+		uint32_t unk6 = *reinterpret_cast<uint32_t*>(blockBlob);
+		iprintf(indent, "\tunk6 = 0x%08x\n", unk6);
+		blockBlob += sizeof(uint32_t);
+
+		PrintBlocks(indent + 1, blockBlob, end - blockBlob);
 
 	}
 	break;
@@ -347,14 +357,12 @@ bool ParseSingleBlock(unsigned indent, uint8_t* blockBlob, uint32_t cookie, uint
 		iprintf(indent, "\tunk3 = 0x%08x\n", block->unk3);
 		iprintf(indent, "\tunk4 = 0x%08x\n", block->unk4);
 		iprintf(indent, "\tunk5 = 0x%08x\n", block->unk5);
-		iprintf(indent, "\tunk6 = 0x%08x\n", block->unk6);
 
-		assert(block->unk2 == 0x0);
-		assert(block->unk3 == 0x0);
-		assert(block->unk4 == 0x0);
-		assert(block->unk5 == 0x8);
+		//assert(block->unk2 == 0x0);
+		//assert(block->unk3 == 0x0);
+		//assert(block->unk4 == 0x0);
+		//assert(block->unk5 == 0x8);
 		// XXX: Sometimes different
-		//assert(block->unk6 == 0x0);
 	}
 	break;
 	case COOKIE("FOTV"):


### PR DESCRIPTION
As it turns out, every block always starts with a cookie followed by the length of the block. This lets us make the parsing much more robust without having to fully understand everything. I also fixed up a few other things along the way, so now it can handle most things you would throw at it using the offline compiler.